### PR TITLE
feat: add web contact

### DIFF
--- a/layouts/authors/term.html
+++ b/layouts/authors/term.html
@@ -22,6 +22,11 @@
 
           {{ $contacts := $person.contacts }}
           <div class="social my-3">
+            {{ if isset $contacts "web" }}
+              <a href="{{ $contacts.web }}" target="_blank" class="btn btn-outline-dark py-2 my-1">
+                <i class="bi bi-globe align-middle"></i>
+              </a>
+            {{ end }}
             {{ if isset $contacts "email" }}
               <a href="mailto:{{ $contacts.email }}" class="btn btn-outline-dark py-2 my-1">
                 <i class="bi bi-envelope align-middle"></i>


### PR DESCRIPTION
Support for a new contact type is added. This is web page for a given author.

For useage, in the people.json we need to add: `"web": "https://example.org/"`